### PR TITLE
Implement simple dual n-back web app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,8 @@
+# Dual N-Back
+
+A simple browser-based dual n-back game that trains working memory using color and position stimuli. Future audio functionality can be added via the placeholder in the JavaScript code.
+
+## Usage
+Open `index.html` in a web browser. Choose an `N` value and press **Start** to begin. Press **J** when the position of the square matches the one `N` steps earlier, and press **F** when the color matches `N` steps earlier.
+
+No server setup is required.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+<meta charset="UTF-8" />
+<title>Dual N-Back Game</title>
+<link rel="stylesheet" href="style.css" />
+</head>
+<body>
+<h1>Dual N-Back</h1>
+<div id="setup">
+<label for="nValue">N:</label>
+<input type="number" id="nValue" min="1" value="2" />
+<button id="startButton">Start</button>
+</div>
+<div id="game" style="display:none;">
+<div id="grid" class="grid"></div>
+<p>Press <strong>J</strong> if the position matches <em>N</em> steps back.</p>
+<p>Press <strong>F</strong> if the color matches <em>N</em> steps back.</p>
+<p id="status"></p>
+</div>
+<script src="main.js"></script>
+</body>
+</html>

--- a/main.js
+++ b/main.js
@@ -1,0 +1,101 @@
+const grid = document.getElementById('grid');
+const startButton = document.getElementById('startButton');
+const nValue = document.getElementById('nValue');
+const status = document.getElementById('status');
+
+const COLORS = ['red', 'blue', 'green', 'yellow', 'orange', 'purple', 'pink', 'cyan'];
+const SEQUENCE_LENGTH = 20; // number of stimuli in one round
+let n = 2;
+let step = 0;
+let positions = [];
+let colors = [];
+let intervalId = null;
+let awaitingInput = false;
+let scores = { color: { correct: 0, miss: 0 }, position: { correct: 0, miss: 0 } };
+
+// prepare grid
+for (let i = 0; i < 9; i++) {
+  const cell = document.createElement('div');
+  cell.className = 'cell';
+  grid.appendChild(cell);
+}
+
+function playAudioStimulus() {
+  // placeholder for future audio implementation
+}
+
+function resetGame() {
+  positions = [];
+  colors = [];
+  step = 0;
+  scores = { color: { correct: 0, miss: 0 }, position: { correct: 0, miss: 0 } };
+  status.textContent = '';
+  const cells = document.querySelectorAll('.cell');
+  cells.forEach(c => { c.style.backgroundColor = ''; c.classList.remove('active'); });
+}
+
+function showStimulus() {
+  const cells = document.querySelectorAll('.cell');
+  cells.forEach(c => { c.style.backgroundColor = ''; c.classList.remove('active'); });
+
+  const pos = Math.floor(Math.random() * 9);
+  const color = COLORS[Math.floor(Math.random() * COLORS.length)];
+
+  positions.push(pos);
+  colors.push(color);
+
+  const cell = cells[pos];
+  cell.style.backgroundColor = color;
+  cell.classList.add('active');
+
+  playAudioStimulus();
+  awaitingInput = true;
+
+  setTimeout(() => {
+    cell.style.backgroundColor = '';
+  }, 700);
+
+  step++;
+  if (step >= SEQUENCE_LENGTH) {
+    clearInterval(intervalId);
+    intervalId = null;
+    showResults();
+  }
+}
+
+function handleKey(event) {
+  if (!awaitingInput) return;
+  const key = event.key.toLowerCase();
+  const idx = step - 1; // current stimulus index
+  if (key === 'j') {
+    // position check
+    if (idx >= n && positions[idx] === positions[idx - n]) {
+      scores.position.correct++;
+    } else {
+      scores.position.miss++;
+    }
+  } else if (key === 'f') {
+    // color check
+    if (idx >= n && colors[idx] === colors[idx - n]) {
+      scores.color.correct++;
+    } else {
+      scores.color.miss++;
+    }
+  }
+  awaitingInput = false;
+}
+
+document.addEventListener('keydown', handleKey);
+
+function showResults() {
+  status.innerHTML = `Position correct: ${scores.position.correct}, miss: ${scores.position.miss}<br>` +
+                     `Color correct: ${scores.color.correct}, miss: ${scores.color.miss}`;
+}
+
+startButton.addEventListener('click', () => {
+  if (intervalId) return; // game running
+  n = parseInt(nValue.value, 10) || 1;
+  resetGame();
+  document.getElementById('game').style.display = 'block';
+  intervalId = setInterval(showStimulus, 1500);
+});

--- a/style.css
+++ b/style.css
@@ -1,0 +1,29 @@
+body {
+  font-family: sans-serif;
+  text-align: center;
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: repeat(3, 100px);
+  grid-template-rows: repeat(3, 100px);
+  gap: 5px;
+  justify-content: center;
+  margin: 20px auto;
+}
+
+.cell {
+  width: 100px;
+  height: 100px;
+  border: 1px solid #000;
+  box-sizing: border-box;
+}
+
+.cell.active {
+  animation: flash 0.5s;
+}
+
+@keyframes flash {
+  from { opacity: 0.2; }
+  to { opacity: 1; }
+}


### PR DESCRIPTION
## Summary
- add browser-based implementation of the dual n-back game
- show a 3x3 grid and random color stimuli
- allow key presses to indicate position and color matches
- include placeholder for future audio support
- document usage instructions

## Testing
- `python3 -m http.server 8000 >/tmp/server.log 2>&1 &`
- `curl -s http://localhost:8000/index.html | head`


------
https://chatgpt.com/codex/tasks/task_e_684ff1b1ec88832286233c04542e710a